### PR TITLE
twitter: timeline is too narrow

### DIFF
--- a/density.user.css
+++ b/density.user.css
@@ -393,8 +393,6 @@
 		width 175px
 	*
 		font-size unset !important
-	main > div
-		width unset !important
 	.r-1ye8kvj
 		max-width unset
 	.r-1hycxz


### PR DESCRIPTION
Hi, thanks for the project, great idea! :+1:  

I've noticed twitter timeline to be too narrow, and I think with this change it ends up with a more reasonable width. Although maybe I'm missing something, so feel free to reject the PR. 

before: 
![image](https://user-images.githubusercontent.com/291333/187092969-833da3ad-9721-4379-9bf2-5d4cadec91d8.png)

after: 
![image](https://user-images.githubusercontent.com/291333/187092992-21e7265b-0f3b-48c1-be4a-e041265c6d22.png)

